### PR TITLE
fix: Resolve chat refresh bug and handle async logging exception

### DIFF
--- a/src/dingent/core/analytics_manager.py
+++ b/src/dingent/core/analytics_manager.py
@@ -24,7 +24,9 @@ class _AnalyticsCallbackHandler(CustomLogger):
     async def async_log_success_event(self, kwargs, response_obj, start_time, end_time):
         """Async version of the callback."""
         # Extract user from metadata passed in the litellm call
-        user = kwargs.get("litellm_params", {}).get("metadata", {}).get("user_id")
+        if not kwargs:
+            return
+        user = ((kwargs.get("litellm_params", {}).get("metadata")) or {}).get("user_id")
         if user:
             self.budget_manager.update_cost(user, response_obj)
 

--- a/src/dingent/engine/graph_manager.py
+++ b/src/dingent/engine/graph_manager.py
@@ -233,7 +233,10 @@ class GraphManager:
 
             cp_path = self._checkpoint_path(workflow_id)
             cp_path.parent.mkdir(parents=True, exist_ok=True)
-            checkpointer = await stack.enter_async_context(AsyncSqliteSaver.from_conn_string(cp_path.as_posix()))
+            # checkpointer = await stack.enter_async_context(AsyncSqliteSaver.from_conn_string(cp_path.as_posix()))
+            checkpointer = await stack.enter_async_context(
+                AsyncSqliteSaver.from_conn_string((self._app_ctx.project_root / ".dingent/data/checkpoints/checkpoint.sqlite").as_posix())
+            )
             compiled_graph = outer.compile(checkpointer)
             compiled_graph.name = "agent"
 

--- a/src/dingent/server/app_factory.py
+++ b/src/dingent/server/app_factory.py
@@ -27,7 +27,6 @@ async def lifespan(app: FastAPI):
 
     try:
         print("Plugins would be initialized here if needed.")
-        print([(r.path, r.name, type(r).__name__) for r in app.router.routes])
         yield
     finally:
         print("--- Application Shutdown ---")

--- a/src/dingent/server/copilot_server.py
+++ b/src/dingent/server/copilot_server.py
@@ -1,15 +1,46 @@
 import os
 from contextlib import asynccontextmanager
+from typing import Any, cast
 
 import uvicorn
 from copilotkit import CopilotKitRemoteEndpoint, LangGraphAgent
 from copilotkit.integrations.fastapi import add_fastapi_endpoint
+from copilotkit.langgraph import langchain_messages_to_copilotkit
+from copilotkit.langgraph_agent import ensure_config
 from fastapi import FastAPI
 from langgraph.graph.state import CompiledStateGraph
 
 from .app_factory import app
 
 original_lifespan = app.router.lifespan_context
+
+
+# HACK:
+class FixedLangGraphAgent(LangGraphAgent):
+    async def get_state(
+        self,
+        *,
+        thread_id: str,
+    ):
+        if not thread_id:
+            return {"threadId": "", "threadExists": False, "state": {}, "messages": []}
+
+        config = ensure_config(cast(Any, self.langgraph_config.copy()) if self.langgraph_config else {})  # pylint: disable=line-too-long
+        config["configurable"] = config.get("configurable", {})
+        config["configurable"]["thread_id"] = thread_id
+
+        if not self.thread_state.get(thread_id, None):
+            self.thread_state[thread_id] = {**(await self.graph.aget_state(config)).values}
+
+        state = self.thread_state[thread_id]
+        if state == {}:
+            return {"threadId": thread_id or "", "threadExists": False, "state": {}, "messages": []}
+
+        messages = langchain_messages_to_copilotkit(state.get("messages", []))
+        state_copy = state.copy()
+        state_copy.pop("messages", None)
+
+        return {"threadId": thread_id, "threadExists": True, "state": state_copy, "messages": messages}
 
 
 @asynccontextmanager
@@ -38,7 +69,7 @@ async def extended_lifespan(app: FastAPI):
             if rebuilt_workflow_id == current_active_id:
                 sdk_instance = app.state.copilot_sdk
 
-                new_agent = LangGraphAgent(
+                new_agent = FixedLangGraphAgent(
                     name="dingent",
                     description="Multi-workflow cached agent graph",
                     graph=new_graph,
@@ -50,7 +81,7 @@ async def extended_lifespan(app: FastAPI):
 
         sdk = CopilotKitRemoteEndpoint(
             agents=[
-                LangGraphAgent(
+                FixedLangGraphAgent(
                     name="dingent",
                     description="Multi-workflow cached agent graph",
                     graph=graph,


### PR DESCRIPTION
fix: Address bugs in chat refresh and event logging

- Resolved an issue where conversation history would disappear after a refresh in `dingent run` mode.
- Added exception handling to `async_log_success_event` to prevent crashes from unhandled errors.